### PR TITLE
Add variable grip-update-after-change

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Run `M-x customize-group RET grip RET` or set the variables.
 ;; A GitHub password or auth token for API auth
 (setq grip-github-password "")
 
+;; When nil, update the preview after file saves only, instead of also
+;; after every text change
+(setq grip-update-after-change nil)
+
 ;; Use embedded webkit to previe
 ;; This requires GNU/Emacs version >= 26 and built with the `--with-xwidgets`
 ;; option.

--- a/grip-mode.el
+++ b/grip-mode.el
@@ -66,6 +66,12 @@
   :type 'string
   :group 'grip)
 
+(defcustom grip-update-after-change t
+  "Update the grip review after every text change. When nil, only
+update the preview on file save."
+  :type 'boolean
+  :group 'grip)
+
 (defcustom grip-preview-use-webkit t
   "Use embedded webkit to preview.
 
@@ -154,7 +160,8 @@ Use default browser unless `xwidget' is avaliable."
 
 (defun grip--preview-md ()
   "Render and preview markdown with grip."
-  (add-hook 'after-change-functions #'grip-refresh-md nil t)
+  (when grip-update-after-change
+    (add-hook 'after-change-functions #'grip-refresh-md nil t))
   (add-hook 'after-save-hook #'grip-refresh-md nil t)
 
   (setq grip--preview-file
@@ -174,7 +181,8 @@ Use default browser unless `xwidget' is avaliable."
 
 (defun grip--preview-org ()
   "Render and preview org with grip."
-  ;; (add-hook 'after-change-functions #'grip-org-to-md nil t)
+  ;; (when grip-update-after-change
+  ;;   (add-hook 'after-change-functions #'grip-org-to-md nil t))
   (add-hook 'after-save-hook #'grip-org-to-md nil t)
 
   (setq grip--preview-file (expand-file-name (grip-org-to-md)))


### PR DESCRIPTION
I wanted to change the default behaviour of having the preview update after every change, to reduce the number of requests being made. For me, updating the preview on file save will suffice. Default behaviour is unchanged.

- Explain in doc
- Define variable
- Check variable value when adding to hook for every text change