### PR TITLE
Adding variable to define Custom browser to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ Run `M-x customize-group RET grip RET` or set the variables.
 ;; Path to the grip binary
 (setq grip-binary-path "/path/to/grip")
 
+;; You can use this variable to define another browser
+;; to use when loading previews. By default this value is `nil`
+;; meaning use default browser defined by your system
+(setq grip-url-browser "custom_browser")
+
 ;; A GitHub username for API authentication
 (setq grip-github-user "")
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Run `M-x customize-group RET grip RET` or set the variables.
 ;; meaning use default browser defined by your system
 (setq grip-url-browser "custom_browser")
 
+;; If you want to pass arguements to your custom browser then use
+(setq grip-url-args '("arg1" "arg2" "etc"))
+
 ;; A GitHub username for API authentication
 (setq grip-github-user "")
 

--- a/grip-mode.el
+++ b/grip-mode.el
@@ -62,6 +62,10 @@ Use default browser if nil."
   :type '(choice (const :tag "None" nil) string)
   :group 'grip)
 
+(defcustom grip-url-args nil
+  "A list of strings defining options for `grip-url-browser'."
+  :type '(repeat (string :tag "Argument")))
+
 (defcustom grip-github-user ""
   "A GitHub username for API authentication."
   :type 'string
@@ -108,7 +112,9 @@ option."
 Use default browser if nil."
   (when grip-url-browser
     (setq-local browse-url-generic-program grip-url-browser
-                browse-url-browser-function 'browse-url-generic))
+                browse-url-browser-function 'browse-url-generic)
+    (when grip-url-args
+      (setq-local browse-url-generic-args grip-url-args)))
   (browse-url url))
 
 (defun grip--browse-url (url)

--- a/grip-mode.el
+++ b/grip-mode.el
@@ -110,12 +110,13 @@ option."
 (defun grip--browser (url)
   "Use browser specified by user to load URL.
 Use default browser if nil."
-  (when grip-url-browser
-    (setq-local browse-url-generic-program grip-url-browser
-                browse-url-browser-function 'browse-url-generic))
-  (when grip-url-args
-    (setq-local browse-url-generic-args grip-url-args))
-  (browse-url url))
+  (if grip-url-browser
+      (let ((browse-url-generic-program grip-url-browser)
+            (browse-url-generic-args grip-url-args))
+        (ignore browse-url-generic-program)
+        (ignore browse-url-generic-args)
+        (browse-url-generic url))
+    (browse-url url)))
 
 (defun grip--browse-url (url)
   "Ask the browser to load URL.

--- a/grip-mode.el
+++ b/grip-mode.el
@@ -112,9 +112,9 @@ option."
 Use default browser if nil."
   (when grip-url-browser
     (setq-local browse-url-generic-program grip-url-browser
-                browse-url-browser-function 'browse-url-generic)
-    (when grip-url-args
-      (setq-local browse-url-generic-args grip-url-args)))
+                browse-url-browser-function 'browse-url-generic))
+  (when grip-url-args
+    (setq-local browse-url-generic-args grip-url-args))
   (browse-url url))
 
 (defun grip--browse-url (url)

--- a/grip-mode.el
+++ b/grip-mode.el
@@ -56,6 +56,12 @@
   :type 'file
   :group 'grip)
 
+(defcustom grip-url-browser nil
+  "Browser to launch Markdown/Org previews.
+Use default browser if nil."
+  :type 'string
+  :group 'grip)
+
 (defcustom grip-github-user ""
   "A GitHub username for API authentication."
   :type 'string
@@ -81,7 +87,6 @@ option."
   :type 'boolean
   :group 'grip)
 
-
 
 ;; Externals
 (declare-function xwidget-buffer 'xwidget)
@@ -98,6 +103,16 @@ option."
 (defvar-local grip--preview-file nil
   "The preview file for grip process.")
 
+(defun grip--browser (url)
+  "Use browser specified by user to load URL.
+Use default browser if nil."
+  (if grip-url-browser
+      (progn
+       (setq-local browse-url-generic-program grip-url-browser
+                   browse-url-browser-function 'browse-url-generic)
+       (browse-url url))
+  (browse-url url)))
+
 (defun grip--browse-url (url)
   "Ask the browser to load URL.
 
@@ -110,7 +125,7 @@ Use default browser unless `xwidget' is available."
           (when (buffer-live-p buf)
             (and (eq buf (current-buffer)) (quit-window))
             (pop-to-buffer buf))))
-    (browse-url url)))
+    (grip--browser url)))
 
 (defun grip--preview-url ()
   "Return grip preview url."

--- a/grip-mode.el
+++ b/grip-mode.el
@@ -59,7 +59,7 @@
 (defcustom grip-url-browser nil
   "Browser to launch Markdown/Org previews.
 Use default browser if nil."
-  :type 'string
+  :type '(choice (const :tag "None" nil) string)
   :group 'grip)
 
 (defcustom grip-github-user ""
@@ -106,12 +106,10 @@ option."
 (defun grip--browser (url)
   "Use browser specified by user to load URL.
 Use default browser if nil."
-  (if grip-url-browser
-      (progn
-       (setq-local browse-url-generic-program grip-url-browser
-                   browse-url-browser-function 'browse-url-generic)
-       (browse-url url))
-  (browse-url url)))
+  (when grip-url-browser
+    (setq-local browse-url-generic-program grip-url-browser
+                browse-url-browser-function 'browse-url-generic))
+  (browse-url url))
 
 (defun grip--browse-url (url)
   "Ask the browser to load URL.


### PR DESCRIPTION
Add an option for user to specify using different browser(other than default one) for org/markdown previews. Its working for me right now, but will need further  testing for any edge cases(if they exist).

Also updated README to include how to set the variable.