### PR TITLE
include support for `theme` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Run `M-x customize-group RET grip RET` or set the variables.
 
 ;; Sleep seconds to ensure the server starts
 (setq grip-sleep-time 2)
+
+;; Choose theme
+(setq grip-theme 'dark)
 ```
 
 If you don't set them you may have limitation to access Github APIs. Please

--- a/grip-mode.el
+++ b/grip-mode.el
@@ -116,7 +116,11 @@ When nil, only update the preview on file save."
   :type 'integer
   :group 'grip)
 
-
+(defcustom grip-theme 'light
+  "Display theme, `light' or `dark', default is light."
+  :type '(choice (const :tag "light" light)
+                 (const :tag "dark" dark))
+  :group 'grip)
 
 ;; Externals
 (declare-function xwidget-buffer "xwidget")
@@ -192,6 +196,7 @@ Use default browser unless `xwidget' is available."
                                (format "--user=%s" grip-github-user)
                                (format "--pass=%s" grip-github-password)
                                (format "--title=%s - Grip" (buffer-name))
+                               (format "--theme=%s" grip-theme)
                                grip--preview-file
                                (number-to-string grip--port)))
           (message "Preview `%s' on %s" buffer-file-name (grip--preview-url))


### PR DESCRIPTION
Hi! Grip uses light theme by default and i would like to preview it on dark mode, giving this as an option to the user. Default behaviour is untouched.

Thanks in advance!