### PR TITLE
add support for markdown-ts-mode

### DIFF
--- a/grip-mode.el
+++ b/grip-mode.el
@@ -266,7 +266,8 @@ Use default browser unless `xwidget' is available."
     (add-hook 'kill-emacs-hook #'grip-stop-preview nil t)
     (cond ((derived-mode-p 'org-mode)
            (grip--preview-org))
-          ((derived-mode-p 'markdown-mode)
+          ((or (derived-mode-p 'markdown-mode)
+               (derived-mode-p 'markdown-ts-mode))
            (grip--preview-md))
           (t
            (grip-mode -1)

--- a/grip-mode.el
+++ b/grip-mode.el
@@ -266,8 +266,7 @@ Use default browser unless `xwidget' is available."
     (add-hook 'kill-emacs-hook #'grip-stop-preview nil t)
     (cond ((derived-mode-p 'org-mode)
            (grip--preview-org))
-          ((or (derived-mode-p 'markdown-mode)
-               (derived-mode-p 'markdown-ts-mode))
+          ((derived-mode-p '(markdown-mode markdown-ts-mode))
            (grip--preview-md))
           (t
            (grip-mode -1)


### PR DESCRIPTION
`markdown-ts-mode` is not a derived mode off `markdown-mode` so special case it.
