### PR TITLE
feat: support real-time refresh for markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Run `M-x customize-group RET grip RET` or set the variables.
 
 ;; Sleep seconds to ensure the server starts
 (setq grip-sleep-time 2)
+
+;; Set to allow real-time refresh
+(setq grip-real-time-refresh t)
 ```
 
 If you don't set them you may have limitation to access Github APIs. Please


### PR DESCRIPTION
 - Provided new variable `grip-real-time-refresh` to enable such feature
 - Changed to remove preview file even the process is not existed

## Note

I've only tried using [mdopen](https://github.com/immanelg/mdopen) for the renderer, I assume there is no special handling for other renderer.