### PR TITLE
Honor `grip-theme` for the mdopen backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Instant Github-flavored Markdown/Org preview using [Grip](https://github.com/joe
 - [Grip](https://github.com/joeyespo/grip): `pip install grip`
 
 ### Alternative markdown preview without accessing GitHub API
-- [mdopen](https://github.com/immanelg/mdopen): `cargo install mdopen`
+- [mdopen](https://github.com/immanelg/mdopen) (`>=0.6.0` for `grip-theme` support): `cargo install mdopen`
 - [go-grip](https://github.com/chrishrb/go-grip): `go install github.com/chrishrb/go-grip@latest`
 
 ## Install

--- a/grip-mode.el
+++ b/grip-mode.el
@@ -195,6 +195,7 @@ Use default browser unless `xwidget' is available."
                               (format " *mdopen-%d*" grip--port)
                               "mdopen"
                               (format "--port=%d" grip--port)
+                              (format "--theme=%s" grip-theme)
                               "--browser="
                               "--reload"
                               (format "%s.md" (file-name-base grip--preview-file))))


### PR DESCRIPTION
The `go-grip` branch already passes `--theme=<grip-theme>`; the `mdopen` branch did not. 

**NOTE:** Blocked on immanelg/mdopen#40 — please hold merge until _mdopen v0.6.0_ is released with the `--theme` flag
